### PR TITLE
Implemented 3D object slicing

### DIFF
--- a/Assets/Scenes/FirstScene.unity
+++ b/Assets/Scenes/FirstScene.unity
@@ -281,7 +281,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &259213156
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -289,7 +289,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 259213155}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 901c8ec638365af48af1b82148428769, type: 3}
   m_Name: 
@@ -356,7 +356,7 @@ Transform:
   m_GameObject: {fileID: 259213155}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.2479591, y: 1.2964089, z: -12.002939}
+  m_LocalPosition: {x: -2.2479591, y: 0.52, z: -12.002939}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -439,7 +439,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &309604030
 Transform:
   m_ObjectHideFlags: 0
@@ -449,7 +449,7 @@ Transform:
   m_GameObject: {fileID: 309604029}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.477959, y: -0.18640894, z: 12.482939}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -463,6 +463,111 @@ Transform:
   - {fileID: 259213158}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &340885096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 340885097}
+  - component: {fileID: 340885100}
+  - component: {fileID: 340885099}
+  - component: {fileID: 340885098}
+  m_Layer: 7
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &340885097
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340885096}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.7, y: 22.29, z: -15.94}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &340885098
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340885096}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &340885099
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340885096}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &340885100
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340885096}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &345094363
 GameObject:
   m_ObjectHideFlags: 0
@@ -561,8 +666,8 @@ Transform:
   m_GameObject: {fileID: 345094363}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6.707959, y: 1.5764089, z: -12.482939}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -6.707959, y: 0.76, z: -12.482939}
+  m_LocalScale: {x: 0.54038, y: 0.54038, z: 0.54038}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1965073519}
@@ -580,7 +685,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01b188c99f6c20d4591590b6a99608ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  jumpForce: 100
+  jumpForce: 150
   runSpeed: 150
   movementSmoothing: 0.05
   whatIsGround:
@@ -650,7 +755,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: -0.00000071525574, y: 0.00000059604645}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -661,7 +766,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 2.5656939, y: 2.5656936}
   m_EdgeRadius: 0
 --- !u!114 &345094371
 MonoBehaviour:
@@ -696,7 +801,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &388765951
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -704,7 +809,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 388765950}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 901c8ec638365af48af1b82148428769, type: 3}
   m_Name: 
@@ -965,7 +1070,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &507373790
 Transform:
   m_ObjectHideFlags: 0
@@ -975,12 +1080,11 @@ Transform:
   m_GameObject: {fileID: 507373789}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.477959, y: -0.18640894, z: 12.482939}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 806957218}
-  - {fileID: 658163515}
   - {fileID: 509976158}
   - {fileID: 388765955}
   m_Father: {fileID: 0}
@@ -1105,8 +1209,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 509976154}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.2635964, y: -0.26866493, z: 0.07670352, w: 0.92328364}
-  m_LocalPosition: {x: -0.62849903, y: 7.976, z: -16.801994}
+  m_LocalRotation: {x: 0.25075278, y: -0.39144298, z: 0.1117565, w: 0.8782972}
+  m_LocalPosition: {x: 1.7035327, y: 7.976, z: -19.16805}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1172,7 +1276,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 1000
+  far clip plane: 5
   field of view: 60
   orthographic: 1
   orthographic size: 6.4037843
@@ -1199,12 +1303,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.000000029802322, y: -4.440892e-16, z: -1.323489e-23, w: 1}
-  m_LocalPosition: {x: -6.7079597, y: 1.5764089, z: -22.482939}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.707959, y: 0.76, z: -15.082939}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 981357722}
+  - {fileID: 1515672925}
   m_Father: {fileID: 309604030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &519420033
@@ -1241,6 +1345,199 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &520788829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 520788830}
+  - component: {fileID: 520788833}
+  - component: {fileID: 520788832}
+  - component: {fileID: 520788831}
+  m_Layer: 7
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &520788830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520788829}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 16.53, y: 22.29, z: -15.94}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &520788831
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520788829}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &520788832
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520788829}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &520788833
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520788829}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &585675336
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 585675337}
+  - component: {fileID: 585675339}
+  - component: {fileID: 585675338}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &585675337
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585675336}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1515672925}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &585675338
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585675336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 7.4}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_TargetMovementOnly: 1
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_CameraDistance: 10
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_DeadZoneDepth: 0
+  m_UnlimitedSoftZone: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+  m_GroupFramingMode: 2
+  m_AdjustmentMode: 0
+  m_GroupFramingSize: 0.8
+  m_MaxDollyIn: 5000
+  m_MaxDollyOut: 5000
+  m_MinimumDistance: 1
+  m_MaximumDistance: 5000
+  m_MinimumFOV: 3
+  m_MaximumFOV: 60
+  m_MinimumOrthoSize: 1
+  m_MaximumOrthoSize: 5000
+--- !u!114 &585675339
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585675336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &658163514
 GameObject:
   m_ObjectHideFlags: 0
@@ -1268,12 +1565,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 658163514}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.02, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 13.902849, y: 20.816254, z: -9.629689}
   m_LocalScale: {x: 16.272564, y: 0.17783, z: 26.254028}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 507373790}
+  m_Father: {fileID: 1610357721}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &658163516
 BoxCollider:
@@ -1371,7 +1668,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 680434066}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.0000001234112, y: 0.00000008016955, z: -0.00000004898781, w: 1}
+  m_LocalRotation: {x: -0.000000025761171, y: 0.000000027637647, z: -0.0000000023509292, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1425,6 +1722,111 @@ MonoBehaviour:
         m_Calls: []
   m_LegacyBlendHint: 0
   m_ComponentOwner: {fileID: 447435732}
+--- !u!1 &684167661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 684167662}
+  - component: {fileID: 684167665}
+  - component: {fileID: 684167664}
+  - component: {fileID: 684167663}
+  m_Layer: 7
+  m_Name: Cube (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &684167662
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684167661}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 13.6, y: 22.29, z: -9.45}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &684167663
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684167661}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &684167664
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684167661}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &684167665
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684167661}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &786564332
 GameObject:
   m_ObjectHideFlags: 0
@@ -1585,7 +1987,7 @@ Transform:
   m_GameObject: {fileID: 806957217}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6.67, y: 0.976, z: -7.3}
+  m_LocalPosition: {x: -6.67, y: 0.976, z: -11.64}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1697,173 +2099,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 345094371}
---- !u!1 &893867524
-GameObject:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 893867525}
-  - component: {fileID: 893867528}
-  - component: {fileID: 893867527}
-  - component: {fileID: 893867526}
-  m_Layer: 0
-  m_Name: cm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &893867525
-Transform:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893867524}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 981357722}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &893867526
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893867524}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_BindingMode: 5
-  m_FollowOffset: {x: 0, y: 0, z: -10}
-  m_XDamping: 1
-  m_YDamping: 1
-  m_ZDamping: 1
-  m_AngularDampingMode: 0
-  m_PitchDamping: 0
-  m_YawDamping: 0
-  m_RollDamping: 0
-  m_AngularDamping: 0
---- !u!114 &893867527
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893867524}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
-  m_LookaheadTime: 0
-  m_LookaheadSmoothing: 0
-  m_LookaheadIgnoreY: 0
-  m_HorizontalDamping: 0.5
-  m_VerticalDamping: 0.5
-  m_ScreenX: 0.5
-  m_ScreenY: 0.5
-  m_DeadZoneWidth: 0.14
-  m_DeadZoneHeight: 0.16
-  m_SoftZoneWidth: 0.8
-  m_SoftZoneHeight: 0.8
-  m_BiasX: 0
-  m_BiasY: 0
-  m_CenterOnActivate: 1
---- !u!114 &893867528
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893867524}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &981357721
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 981357722}
-  - component: {fileID: 981357723}
-  m_Layer: 0
-  m_Name: Virtual Camera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &981357722
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 981357721}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.000000015296575, y: 0.000000038820087, z: 0.0000000068894814, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 893867525}
-  m_Father: {fileID: 519420032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &981357723
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 981357721}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ExcludedPropertiesInInspector:
-  - m_Script
-  m_LockStageInInspector: 
-  m_StreamingVersion: 20170927
-  m_Priority: 10
-  m_StandbyUpdate: 2
-  m_LookAt: {fileID: 345094367}
-  m_Follow: {fileID: 345094367}
-  m_Lens:
-    FieldOfView: 60
-    OrthographicSize: 6.4037843
-    NearClipPlane: 0.3
-    FarClipPlane: 1000
-    Dutch: 0
-    ModeOverride: 0
-    LensShift: {x: 0, y: 0}
-    GateFit: 2
-    FocusDistance: 10
-    m_SensorSize: {x: 1, y: 1}
-  m_Transitions:
-    m_BlendHint: 0
-    m_InheritPosition: 0
-    m_OnCameraLive:
-      m_PersistentCalls:
-        m_Calls: []
-  m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 893867525}
 --- !u!1 &1116610295
 GameObject:
   m_ObjectHideFlags: 3
@@ -1889,7 +2124,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1116610295}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.0000001234112, y: 0.00000008016955, z: -0.00000004898781, w: 1}
+  m_LocalRotation: {x: -0.000000025761171, y: 0.000000027637647, z: -0.0000000023509292, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -2095,7 +2330,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1214891841}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.036325008, y: -0.0000000069694974, z: 0.000000021001874, w: 0.99934006}
+  m_LocalRotation: {x: -0.036324937, y: -0.00000018139208, z: 0.000000073472975, w: 0.99934006}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -2232,6 +2467,78 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!1 &1515672924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1515672925}
+  - component: {fileID: 1515672926}
+  m_Layer: 0
+  m_Name: Virtual Camera (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1515672925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515672924}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 585675337}
+  m_Father: {fileID: 519420032}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1515672926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515672924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 345094367}
+  m_Follow: {fileID: 345094367}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 6.4037843
+    NearClipPlane: 0.3
+    FarClipPlane: 5
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 585675337}
 --- !u!1 &1536855776
 GameObject:
   m_ObjectHideFlags: 0
@@ -2241,6 +2548,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1536855778}
+  - component: {fileID: 1536855779}
   - component: {fileID: 1536855777}
   m_Layer: 0
   m_Name: Manager
@@ -2256,17 +2564,15 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1536855776}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c09a7adcddfdede4abb2c1c0d7693535, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   transitionablePairs2D:
   - {fileID: 345094371}
-  - {fileID: 259213156}
   transitionablePairs3D:
   - {fileID: 806957223}
-  - {fileID: 388765951}
   ide2D: {fileID: 309604029}
   ide3D: {fileID: 507373789}
 --- !u!4 &1536855778
@@ -2284,6 +2590,20 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1536855779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1536855776}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a5b528f2ef90b44db15b30d23245d55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 806957218}
+  test: {fileID: 340885096}
 --- !u!1 &1608303117
 GameObject:
   m_ObjectHideFlags: 0
@@ -2414,6 +2734,41 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1610357720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1610357721}
+  m_Layer: 7
+  m_Name: GroundObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1610357721
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610357720}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -16.92285, y: -20.816254, z: 9.629689}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 658163515}
+  - {fileID: 340885097}
+  - {fileID: 520788830}
+  - {fileID: 684167662}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1673432933
 GameObject:
   m_ObjectHideFlags: 0
@@ -2653,7 +3008,7 @@ Transform:
   m_GameObject: {fileID: 1965073518}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalPosition: {x: 0, y: -1.28, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2793,3 +3148,4 @@ SceneRoots:
   - {fileID: 309604030}
   - {fileID: 507373790}
   - {fileID: 1536855778}
+  - {fileID: 1610357721}

--- a/Assets/Scenes/FirstScene.unity
+++ b/Assets/Scenes/FirstScene.unity
@@ -492,7 +492,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10.7, y: 22.29, z: -15.94}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1.2321, z: 2.9475}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1610357721}
@@ -1055,6 +1055,113 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
+--- !u!1 &483052994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 483052995}
+  - component: {fileID: 483052998}
+  - component: {fileID: 483052997}
+  - component: {fileID: 483052996}
+  m_Layer: 7
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &483052995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483052994}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 22.91, y: 22.61, z: -11.04}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &483052996
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483052994}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &483052997
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483052994}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &483052998
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483052994}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &507373789
 GameObject:
   m_ObjectHideFlags: 0
@@ -1567,7 +1674,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 13.902849, y: 20.816254, z: -9.629689}
-  m_LocalScale: {x: 16.272564, y: 0.17783, z: 26.254028}
+  m_LocalScale: {x: 62.90485, y: 0.17783, z: 55.81344}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1610357721}
@@ -2603,7 +2710,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 806957218}
-  test: {fileID: 340885096}
+  obj1: {fileID: 2137838267}
+  obj2: {fileID: 340885096}
+  obj3: {fileID: 483052994}
 --- !u!1 &1608303117
 GameObject:
   m_ObjectHideFlags: 0
@@ -2767,6 +2876,9 @@ Transform:
   - {fileID: 340885097}
   - {fileID: 520788830}
   - {fileID: 684167662}
+  - {fileID: 2137838268}
+  - {fileID: 483052995}
+  - {fileID: 1701565181}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1673432933
@@ -2853,6 +2965,113 @@ Transform:
   m_Children: []
   m_Father: {fileID: 309604030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1701565180
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1701565181}
+  - component: {fileID: 1701565184}
+  - component: {fileID: 1701565183}
+  - component: {fileID: 1701565182}
+  m_Layer: 7
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1701565181
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1701565180}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 24.86, y: 22, z: -10.86}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1701565182
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1701565180}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1701565183
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1701565180}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1701565184
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1701565180}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1891656234
 GameObject:
   m_ObjectHideFlags: 0
@@ -3141,6 +3360,111 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2137838267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2137838268}
+  - component: {fileID: 2137838271}
+  - component: {fileID: 2137838270}
+  - component: {fileID: 2137838269}
+  m_Layer: 7
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2137838268
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137838267}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 19.2, y: 22.3, z: -10.77}
+  m_LocalScale: {x: 3.3850875, y: 3.3850875, z: 3.3850875}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1610357721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &2137838269
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137838267}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2137838270
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137838267}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2137838271
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137838267}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/General/DimensionSwitcher.cs
+++ b/Assets/Scripts/General/DimensionSwitcher.cs
@@ -1,32 +1,30 @@
-using System;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 
-public class DimensionSwitcher : MonoBehaviour
-{
+public class DimensionSwitcher : MonoBehaviour {
     public Transform player;
-    private Plane slicingPlane;
+    private Plane _slicingPlane;
     public GameObject obj1;
     public GameObject obj2;
     public GameObject obj3;
     // Store the intersection points
-    private List<Vector3> intersectionPoints = new List<Vector3>();
+    private List<Vector3> _intersectionPoints = new List<Vector3>();
 
     void Update() {
         // Trigger dimension switch
         if (Input.GetKeyDown(KeyCode.T)){
             Vector3 forwardDirection = player.forward;
-            slicingPlane = new Plane(forwardDirection, player.position);
+            _slicingPlane = new Plane(forwardDirection, player.position);
             Debug.DrawLine(player.position, player.position + forwardDirection, Color.green);
-            DrawSlicingPlane(slicingPlane, player.position);
+            DrawSlicingPlane(_slicingPlane, player.position);
             // Slice the object and generate 2D geometry
             SliceObject(obj1);
-            Generate2DPolygonFromIntersections();
+            Generate2DPolygonFromIntersections(_intersectionPoints);
             SliceObject(obj2);
-            Generate2DPolygonFromIntersections();
+            Generate2DPolygonFromIntersections(_intersectionPoints);
             SliceObject(obj3);
-            Generate2DPolygonFromIntersections();
+            Generate2DPolygonFromIntersections(_intersectionPoints);
         }
     }
     
@@ -34,10 +32,8 @@ public class DimensionSwitcher : MonoBehaviour
     void DrawSlicingPlane(Plane slicingPlane, Vector3 planeCenter, float planeSize = 5.0f){
         // Get the normal of the plane
         Vector3 planeNormal = slicingPlane.normal;
-
         // Draw the normal direction
         Debug.DrawRay(planeCenter, planeNormal * 2.0f, Color.red); // Red line for the normal
-
         // Find two vectors that are perpendicular to the plane's normal
         Vector3 planeRight = Vector3.Cross(planeNormal, Vector3.up).normalized;
         if (planeRight == Vector3.zero)
@@ -45,13 +41,11 @@ public class DimensionSwitcher : MonoBehaviour
             planeRight = Vector3.Cross(planeNormal, Vector3.forward).normalized;
         
         Vector3 planeUp = Vector3.Cross(planeNormal, planeRight).normalized;
-
         // Calculate the four corners of a square on the plane
         Vector3 corner1 = planeCenter + (planeRight * planeSize / 2) + (planeUp * planeSize / 2);
         Vector3 corner2 = planeCenter + (planeRight * planeSize / 2) - (planeUp * planeSize / 2);
         Vector3 corner3 = planeCenter - (planeRight * planeSize / 2) - (planeUp * planeSize / 2);
         Vector3 corner4 = planeCenter - (planeRight * planeSize / 2) + (planeUp * planeSize / 2);
-
         // Draw the square representing a portion of the plane
         Debug.DrawLine(corner1, corner2, Color.green); // Green for the plane surface
         Debug.DrawLine(corner2, corner3, Color.green);
@@ -61,8 +55,8 @@ public class DimensionSwitcher : MonoBehaviour
 
     void SliceObject(GameObject obj) {
         MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
-        if (meshFilter == null) return;
-
+        if (!meshFilter) return;
+        
         Mesh mesh = meshFilter.mesh;
         Vector3[] localVertices = mesh.vertices; // These are local-space vertices
 
@@ -77,7 +71,7 @@ public class DimensionSwitcher : MonoBehaviour
         int[] triangles = mesh.triangles;
 
         // Clear previous intersection points
-        intersectionPoints.Clear();
+        _intersectionPoints.Clear();
 
         // Iterate over all triangles in the mesh
         for (int i = 0; i < triangles.Length; i += 3){
@@ -86,127 +80,98 @@ public class DimensionSwitcher : MonoBehaviour
             Vector3 v2 = worldVertices[triangles[i + 2]];
             
             // Determine the side of the slicing plane for each vertex
-            bool v0Above = slicingPlane.GetSide(v0);
-            bool v1Above = slicingPlane.GetSide(v1);
-            bool v2Above = slicingPlane.GetSide(v2);
+            bool v0Above = _slicingPlane.GetSide(v0);
+            bool v1Above = _slicingPlane.GetSide(v1);
+            bool v2Above = _slicingPlane.GetSide(v2);
             
             // Check if this triangle intersects the slicing plane
             // Find the intersection points on the triangle's edges
             if (v0Above != v1Above){
                 Vector3 intersection = FindIntersection(v0, v1);
-                intersectionPoints.Add(intersection);
+                _intersectionPoints.Add(intersection);
             }
             if (v1Above != v2Above){
                 Vector3 intersection = FindIntersection(v1, v2);
-                intersectionPoints.Add(intersection);
+                _intersectionPoints.Add(intersection);
             }
             if (v2Above != v0Above){
                 Vector3 intersection = FindIntersection(v2, v0);
-                intersectionPoints.Add(intersection);
+                _intersectionPoints.Add(intersection);
             }
         }
     }
 
     // Function to find the intersection point between two vertices and the slicing plane
     Vector3 FindIntersection(Vector3 v1, Vector3 v2){
-        float distance1 = slicingPlane.GetDistanceToPoint(v1);
-        float distance2 = slicingPlane.GetDistanceToPoint(v2);
+        float distance1 = _slicingPlane.GetDistanceToPoint(v1);
+        float distance2 = _slicingPlane.GetDistanceToPoint(v2);
         float t = distance1 / (distance1 - distance2);
         return Vector3.Lerp(v1, v2, t);  // Interpolating to find the intersection point
     }
-
-    // Generate a 2D polygon from the intersection points
-    void Generate2DPolygonFromIntersections(){
-        if (intersectionPoints.Count < 3) return;
-        List<Vector3> polygon2D = new List<Vector3>(); // Change 2d or 3d vectors here
-        foreach (Vector3 intersectionPoint in intersectionPoints)
-            // Convert 3D points into 2D (by discarding Z or using another plane of your choice)
-            polygon2D.Add(intersectionPoint);
-        // Now it is needed to connect these points in a 2D space to create the polygon, triangulate the polygon for rendering in Unity
-        TriangulateAndRender2DPolygon(polygon2D);
-    }
-
-    // A simple function to triangulate and render the 2D polygon
-    void TriangulateAndRender2DPolygon(List<Vector3> polygon2D){
+    
+    // It is needed to connect the intersection points in a 2D space to create the polygon, triangulate the polygon for rendering in Unity
+    void Generate2DPolygonFromIntersections(List<Vector3> polygon2D){
+        if (_intersectionPoints.Count < 3) return; // There is nothing to generate since we need 3 points for at least one triangle
         // Create a new GameObject for the 2D mesh
-        GameObject polygonObject = new GameObject("Sliced2DPolygon", typeof(MeshFilter), typeof(MeshRenderer));
-        
-        // Placeholder material for the polygon (replace with your own material)
+        GameObject polygonObject = new GameObject("Sliced2DPolygon", typeof(MeshFilter), typeof(MeshRenderer), typeof(PolygonCollider2D));
+        // Placeholder material for the polygon
         polygonObject.GetComponent<MeshRenderer>().material = new Material(Shader.Find("Sprites/Default"));
 
-        // Triangulation (assumes the polygon is convex and ordered correctly)
-        for (int i = 0; i < polygon2D.Count; i++) {
-            if (i < 2) continue;
-            // Calculate the area of the triangle formed by the points
-            // If the area is zero, the points are collinear
-            float area = polygon2D[i-2].x * (polygon2D[i-1].y - polygon2D[i].y) +
-                         polygon2D[i-1].x * (polygon2D[i].y - polygon2D[i-2].y) +
-                         polygon2D[i].x * (polygon2D[i-2].y - polygon2D[i-1].y);
-            if (Mathf.Approximately(area, 0.0f)) { 
-                // Calculate distances between each pair of points
-                float d1 = Vector3.Distance(polygon2D[i-2], polygon2D[i-1]);
-                float d2 = Vector3.Distance(polygon2D[i-1], polygon2D[i]);
-                float d3 = Vector3.Distance(polygon2D[i-2], polygon2D[i]);
-
-                // Check which point is in the middle
-                if (Mathf.Approximately(d1 + d2, d3))
-                    // polygon2D[i-1] is in the middle
-                    for (int j = i-1; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
-                else if (Mathf.Approximately(d1 + d3, d2))
-                    // polygon2D[i-2] is in the middle
-                    for (int j = i-2; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
-                else
-                    // polygon2D[i] is in the middle
-                    for (int j = i; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
-                
-                // Remove the last element since it's now a duplicate after shifting
-                polygon2D.RemoveAt(polygon2D.Count - 1);
-                // Decrement 'i' to recheck the current position (since it now contains the next element)
-                i--;
-            }
-        }
-        polygon2D = RoundVector3List(polygon2D, 10);
-        List<Vector3> uniquePolygon2D = polygon2D.Distinct().ToList();
-        SortVerticesClockwise(ref uniquePolygon2D);
+        CleanupVertices(ref polygon2D);
+        SortVerticesClockwise(ref polygon2D);
         List<int> triangles = new List<int>();
-        for (int i = 1; i < uniquePolygon2D.Count - 1; i++){
+        for (int i = 1; i < polygon2D.Count - 1; i++){
             triangles.Add(0);
             triangles.Add(i);
             triangles.Add(i + 1);
         }
-
-        // Convert the 2D points back to 3D for rendering (setting Z = 0))
-        Vector3[] vertices3D = new Vector3[uniquePolygon2D.Count];
-        for (int i = 0; i < uniquePolygon2D.Count; i++){
-            vertices3D[i] = new Vector3(uniquePolygon2D[i].x, uniquePolygon2D[i].y, uniquePolygon2D[i].z);
-            GameObject point = new GameObject("point " + i.ToString());
-            point.transform.position = vertices3D[i];
-        }
         
-        // Create the 2D mesh
-        Mesh polygonMesh = new Mesh();
-        polygonMesh.vertices = vertices3D;
-        polygonMesh.triangles = triangles.ToArray();
+        // Creating the 2D mesh
+        Mesh polygonMesh = new Mesh {
+            vertices = polygon2D.ToArray(),
+            triangles = triangles.ToArray()
+        };
         polygonMesh.RecalculateNormals();
         polygonMesh.RecalculateBounds();
 
-        // Assign the mesh to the MeshFilter
+        // Assign the created mesh to the MeshFilter
         polygonObject.GetComponent<MeshFilter>().mesh = polygonMesh;
     }
-    // Rounding up coordinates for better precision when using list.Distinct() later
-    List<Vector3> RoundVector3List(List<Vector3> vectors, int decimalPlaces) {
-        List<Vector3> roundedVectors = new List<Vector3>();
-        foreach (Vector3 vec in vectors) {
-            Vector3 roundedVec = new Vector3(
-                // Rounding up every coordinate and then creating a new vector
-                (float)Math.Round(vec.x, decimalPlaces),
-                (float)Math.Round(vec.y, decimalPlaces),
-                (float)Math.Round(vec.z, decimalPlaces)
-            );
-            roundedVectors.Add(roundedVec);
+
+    void CleanupVertices(ref List<Vector3> polygon2D) {
+        // Triangulation (assumes the polygon is convex and ordered correctly)
+        for (int i = 0; i < polygon2D.Count; i++) {
+            if (i < 2) continue; // We can't do any math until we are deeper in the list
+            // Calculate the area of the triangle formed by the points, if it is zero, the points are collinear
+            float area = polygon2D[i-2].x * (polygon2D[i-1].y - polygon2D[i].y) +
+                         polygon2D[i-1].x * (polygon2D[i].y - polygon2D[i-2].y) +
+                         polygon2D[i].x * (polygon2D[i-2].y - polygon2D[i-1].y);
+            if (!Mathf.Approximately(area, 0.0f)) continue; // We don't need to remove one of the point if they are not collinear
+            // Calculate distances between each pair of points
+            float d1 = Vector3.Distance(polygon2D[i-2], polygon2D[i-1]);
+            float d2 = Vector3.Distance(polygon2D[i-1], polygon2D[i]);
+            float d3 = Vector3.Distance(polygon2D[i-2], polygon2D[i]);
+
+            // Check which point is in the middle
+            if (Mathf.Approximately(d1 + d2, d3))
+                // polygon2D[i-1] is in the middle
+                for (int j = i-1; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+            else if (Mathf.Approximately(d1 + d3, d2))
+                // polygon2D[i-2] is in the middle
+                for (int j = i-2; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+            else
+                // polygon2D[i] is in the middle
+                for (int j = i; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+            
+            // Remove the last element since it's now a duplicate after shifting
+            polygon2D.RemoveAt(polygon2D.Count - 1);
+            // Decrement 'i' to recheck the current position (since it now contains the next element)
+            i--;
         }
-        return roundedVectors;
+        // Getting rid of duplicates and sorting the vertices to create triangles more effectively
+        polygon2D = polygon2D.Distinct().ToList();
     }
+    
     //After slicing vertices can be created randomly, so in order to create triangles correctly the vertices have to be sorted clockwise
     void SortVerticesClockwise(ref List<Vector3> vertices){
         // Calculating the centroid (center point) of the polygon

--- a/Assets/Scripts/General/DimensionSwitcher.cs
+++ b/Assets/Scripts/General/DimensionSwitcher.cs
@@ -1,5 +1,7 @@
+using System;
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 public class DimensionSwitcher : MonoBehaviour
 {
@@ -8,14 +10,12 @@ public class DimensionSwitcher : MonoBehaviour
     public GameObject obj1;
     public GameObject obj2;
     public GameObject obj3;
-
     // Store the intersection points
     private List<Vector3> intersectionPoints = new List<Vector3>();
 
-    void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.T))  // Trigger dimension switch
-        {
+    void Update() {
+        // Trigger dimension switch
+        if (Input.GetKeyDown(KeyCode.T)){
             Vector3 forwardDirection = player.forward;
             slicingPlane = new Plane(forwardDirection, player.position);
             Debug.DrawLine(player.position, player.position + forwardDirection, Color.green);
@@ -31,8 +31,7 @@ public class DimensionSwitcher : MonoBehaviour
     }
     
     // For debug purposes
-    void DrawSlicingPlane(Plane slicingPlane, Vector3 planeCenter, float planeSize = 5.0f)
-    {
+    void DrawSlicingPlane(Plane slicingPlane, Vector3 planeCenter, float planeSize = 5.0f){
         // Get the normal of the plane
         Vector3 planeNormal = slicingPlane.normal;
 
@@ -41,11 +40,10 @@ public class DimensionSwitcher : MonoBehaviour
 
         // Find two vectors that are perpendicular to the plane's normal
         Vector3 planeRight = Vector3.Cross(planeNormal, Vector3.up).normalized;
-        if (planeRight == Vector3.zero){
+        if (planeRight == Vector3.zero)
             // If planeNormal is pointing straight up or down, choose another axis to cross with
             planeRight = Vector3.Cross(planeNormal, Vector3.forward).normalized;
-        }
-
+        
         Vector3 planeUp = Vector3.Cross(planeNormal, planeRight).normalized;
 
         // Calculate the four corners of a square on the plane
@@ -76,7 +74,6 @@ public class DimensionSwitcher : MonoBehaviour
         for (int i = 0; i < localVertices.Length; i++)
             // Transform the local vertex by the object's local-to-world matrix
             worldVertices[i] = localToWorld.MultiplyPoint3x4(localVertices[i]);
-
         int[] triangles = mesh.triangles;
 
         // Clear previous intersection points
@@ -87,12 +84,12 @@ public class DimensionSwitcher : MonoBehaviour
             Vector3 v0 = worldVertices[triangles[i]];
             Vector3 v1 = worldVertices[triangles[i + 1]];
             Vector3 v2 = worldVertices[triangles[i + 2]];
-
+            
             // Determine the side of the slicing plane for each vertex
             bool v0Above = slicingPlane.GetSide(v0);
             bool v1Above = slicingPlane.GetSide(v1);
             bool v2Above = slicingPlane.GetSide(v2);
-            // Debug.Log(v0 + ", " + v1 + ", " + v2);
+            
             // Check if this triangle intersects the slicing plane
             // Find the intersection points on the triangle's edges
             if (v0Above != v1Above){
@@ -114,26 +111,17 @@ public class DimensionSwitcher : MonoBehaviour
     Vector3 FindIntersection(Vector3 v1, Vector3 v2){
         float distance1 = slicingPlane.GetDistanceToPoint(v1);
         float distance2 = slicingPlane.GetDistanceToPoint(v2);
-
         float t = distance1 / (distance1 - distance2);
-        // Debug.Log(Vector3.Lerp(v1, v2, t));
         return Vector3.Lerp(v1, v2, t);  // Interpolating to find the intersection point
     }
 
     // Generate a 2D polygon from the intersection points
     void Generate2DPolygonFromIntersections(){
-        if (intersectionPoints.Count < 3){
-            Debug.LogWarning("Not enough points to form a polygon");
-            // Debug.Log(intersectionPoints.Count);
-            return;
-        }
-        
+        if (intersectionPoints.Count < 3) return;
         List<Vector3> polygon2D = new List<Vector3>(); // Change 2d or 3d vectors here
-
         foreach (Vector3 intersectionPoint in intersectionPoints)
             // Convert 3D points into 2D (by discarding Z or using another plane of your choice)
             polygon2D.Add(intersectionPoint);
-        
         // Now it is needed to connect these points in a 2D space to create the polygon, triangulate the polygon for rendering in Unity
         TriangulateAndRender2DPolygon(polygon2D);
     }
@@ -146,40 +134,55 @@ public class DimensionSwitcher : MonoBehaviour
         // Placeholder material for the polygon (replace with your own material)
         polygonObject.GetComponent<MeshRenderer>().material = new Material(Shader.Find("Sprites/Default"));
 
-        // Triangulation: This assumes the polygon is convex and ordered correctly (or you could use a library like LibTessDotNet)
-        List<int> triangles = new List<int>();
-        for (int i = 0; i < polygon2D.Count; i++)
-        {
-            if (i != 0 && polygon2D[i] == polygon2D[i - 1])
-            {
-                // Shift elements one position back starting from the current position
-                for (int j = i; j < polygon2D.Count - 1; j++)
-                {
-                    polygon2D[j] = polygon2D[j + 1];
-                }
+        // Triangulation (assumes the polygon is convex and ordered correctly)
+        for (int i = 0; i < polygon2D.Count; i++) {
+            if (i < 2) continue;
+            // Calculate the area of the triangle formed by the points
+            // If the area is zero, the points are collinear
+            float area = polygon2D[i-2].x * (polygon2D[i-1].y - polygon2D[i].y) +
+                         polygon2D[i-1].x * (polygon2D[i].y - polygon2D[i-2].y) +
+                         polygon2D[i].x * (polygon2D[i-2].y - polygon2D[i-1].y);
+            if (Mathf.Approximately(area, 0.0f)) { 
+                // Calculate distances between each pair of points
+                float d1 = Vector3.Distance(polygon2D[i-2], polygon2D[i-1]);
+                float d2 = Vector3.Distance(polygon2D[i-1], polygon2D[i]);
+                float d3 = Vector3.Distance(polygon2D[i-2], polygon2D[i]);
 
+                // Check which point is in the middle
+                if (Mathf.Approximately(d1 + d2, d3))
+                    // polygon2D[i-1] is in the middle
+                    for (int j = i-1; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+                else if (Mathf.Approximately(d1 + d3, d2))
+                    // polygon2D[i-2] is in the middle
+                    for (int j = i-2; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+                else
+                    // polygon2D[i] is in the middle
+                    for (int j = i; j < polygon2D.Count - 1; j++) polygon2D[j] = polygon2D[j + 1];
+                
                 // Remove the last element since it's now a duplicate after shifting
                 polygon2D.RemoveAt(polygon2D.Count - 1);
-
                 // Decrement 'i' to recheck the current position (since it now contains the next element)
                 i--;
             }
         }
-        for (int i = 1; i < polygon2D.Count - 1; i++){
+        polygon2D = RoundVector3List(polygon2D, 10);
+        List<Vector3> uniquePolygon2D = polygon2D.Distinct().ToList();
+        SortVerticesClockwise(ref uniquePolygon2D);
+        List<int> triangles = new List<int>();
+        for (int i = 1; i < uniquePolygon2D.Count - 1; i++){
             triangles.Add(0);
             triangles.Add(i);
             triangles.Add(i + 1);
         }
 
         // Convert the 2D points back to 3D for rendering (setting Z = 0))
-        Vector3[] vertices3D = new Vector3[polygon2D.Count];
-        for (int i = 0; i < polygon2D.Count; i++){
-            vertices3D[i] = new Vector3(polygon2D[i].x, polygon2D[i].y, polygon2D[i].z);
+        Vector3[] vertices3D = new Vector3[uniquePolygon2D.Count];
+        for (int i = 0; i < uniquePolygon2D.Count; i++){
+            vertices3D[i] = new Vector3(uniquePolygon2D[i].x, uniquePolygon2D[i].y, uniquePolygon2D[i].z);
             GameObject point = new GameObject("point " + i.ToString());
             point.transform.position = vertices3D[i];
         }
-            
-
+        
         // Create the 2D mesh
         Mesh polygonMesh = new Mesh();
         polygonMesh.vertices = vertices3D;
@@ -189,5 +192,33 @@ public class DimensionSwitcher : MonoBehaviour
 
         // Assign the mesh to the MeshFilter
         polygonObject.GetComponent<MeshFilter>().mesh = polygonMesh;
+    }
+    // Rounding up coordinates for better precision when using list.Distinct() later
+    List<Vector3> RoundVector3List(List<Vector3> vectors, int decimalPlaces) {
+        List<Vector3> roundedVectors = new List<Vector3>();
+        foreach (Vector3 vec in vectors) {
+            Vector3 roundedVec = new Vector3(
+                // Rounding up every coordinate and then creating a new vector
+                (float)Math.Round(vec.x, decimalPlaces),
+                (float)Math.Round(vec.y, decimalPlaces),
+                (float)Math.Round(vec.z, decimalPlaces)
+            );
+            roundedVectors.Add(roundedVec);
+        }
+        return roundedVectors;
+    }
+    //After slicing vertices can be created randomly, so in order to create triangles correctly the vertices have to be sorted clockwise
+    void SortVerticesClockwise(ref List<Vector3> vertices){
+        // Calculating the centroid (center point) of the polygon
+        Vector3 centroid = Vector3.zero;
+        foreach (var vertex in vertices) centroid += vertex;
+        centroid /= vertices.Count;
+
+        // Sorting vertices based on their angle from the centroid
+        vertices.Sort((a, b) => {
+            float angleA = Mathf.Atan2(a.y - centroid.y, a.x - centroid.x);
+            float angleB = Mathf.Atan2(b.y - centroid.y, b.x - centroid.x);
+            return angleA.CompareTo(angleB);
+        });
     }
 }

--- a/Assets/Scripts/General/DimensionSwitcher.cs
+++ b/Assets/Scripts/General/DimensionSwitcher.cs
@@ -1,0 +1,166 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class DimensionSwitcher : MonoBehaviour
+{
+    public Transform player;
+    private Plane slicingPlane;
+    public GameObject obj1;
+
+    // Store the intersection points
+    private List<Vector3> intersectionPoints = new List<Vector3>();
+
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.T))  // Trigger dimension switch
+        {
+            Vector3 forwardDirection = player.forward;
+            slicingPlane = new Plane(forwardDirection, player.position);
+            Debug.DrawLine(player.position, player.position + forwardDirection, Color.green);
+            DrawSlicingPlane(slicingPlane, player.position);
+            // Slice the object and generate 2D geometry
+            SliceObject(obj1);
+            Generate2DPolygonFromIntersections();
+        }
+    }
+    
+    // For debug purposes
+    void DrawSlicingPlane(Plane slicingPlane, Vector3 planeCenter, float planeSize = 5.0f)
+    {
+        // Get the normal of the plane
+        Vector3 planeNormal = slicingPlane.normal;
+
+        // Draw the normal direction
+        Debug.DrawRay(planeCenter, planeNormal * 2.0f, Color.red); // Red line for the normal
+
+        // Find two vectors that are perpendicular to the plane's normal
+        Vector3 planeRight = Vector3.Cross(planeNormal, Vector3.up).normalized;
+        if (planeRight == Vector3.zero){
+            // If planeNormal is pointing straight up or down, choose another axis to cross with
+            planeRight = Vector3.Cross(planeNormal, Vector3.forward).normalized;
+        }
+
+        Vector3 planeUp = Vector3.Cross(planeNormal, planeRight).normalized;
+
+        // Calculate the four corners of a square on the plane
+        Vector3 corner1 = planeCenter + (planeRight * planeSize / 2) + (planeUp * planeSize / 2);
+        Vector3 corner2 = planeCenter + (planeRight * planeSize / 2) - (planeUp * planeSize / 2);
+        Vector3 corner3 = planeCenter - (planeRight * planeSize / 2) - (planeUp * planeSize / 2);
+        Vector3 corner4 = planeCenter - (planeRight * planeSize / 2) + (planeUp * planeSize / 2);
+
+        // Draw the square representing a portion of the plane
+        Debug.DrawLine(corner1, corner2, Color.green); // Green for the plane surface
+        Debug.DrawLine(corner2, corner3, Color.green);
+        Debug.DrawLine(corner3, corner4, Color.green);
+        Debug.DrawLine(corner4, corner1, Color.green);
+    }
+
+    void SliceObject(GameObject obj) {
+        MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
+        if (meshFilter == null) return;
+
+        Mesh mesh = meshFilter.mesh;
+        Vector3[] localVertices = mesh.vertices; // These are local-space vertices
+
+        // Get the local-to-world matrix, which includes position, rotation, and scale
+        Matrix4x4 localToWorld = obj.transform.localToWorldMatrix;
+
+        // Convert local vertices to world space, including scaling
+        Vector3[] worldVertices = new Vector3[localVertices.Length];
+        for (int i = 0; i < localVertices.Length; i++)
+            // Transform the local vertex by the object's local-to-world matrix
+            worldVertices[i] = localToWorld.MultiplyPoint3x4(localVertices[i]);
+
+        int[] triangles = mesh.triangles;
+
+        // Clear previous intersection points
+        intersectionPoints.Clear();
+
+        // Iterate over all triangles in the mesh
+        for (int i = 0; i < triangles.Length; i += 3){
+            Vector3 v0 = worldVertices[triangles[i]];
+            Vector3 v1 = worldVertices[triangles[i + 1]];
+            Vector3 v2 = worldVertices[triangles[i + 2]];
+
+            // Determine the side of the slicing plane for each vertex
+            bool v0Above = slicingPlane.GetSide(v0);
+            bool v1Above = slicingPlane.GetSide(v1);
+            bool v2Above = slicingPlane.GetSide(v2);
+            // Debug.Log(v0 + ", " + v1 + ", " + v2);
+            // Check if this triangle intersects the slicing plane
+            // Find the intersection points on the triangle's edges
+            if (v0Above != v1Above){
+                Vector3 intersection = FindIntersection(v0, v1);
+                intersectionPoints.Add(intersection);
+            }
+            if (v1Above != v2Above){
+                Vector3 intersection = FindIntersection(v1, v2);
+                intersectionPoints.Add(intersection);
+            }
+            if (v2Above != v0Above){
+                Vector3 intersection = FindIntersection(v2, v0);
+                intersectionPoints.Add(intersection);
+            }
+        }
+    }
+
+    // Function to find the intersection point between two vertices and the slicing plane
+    Vector3 FindIntersection(Vector3 v1, Vector3 v2){
+        float distance1 = slicingPlane.GetDistanceToPoint(v1);
+        float distance2 = slicingPlane.GetDistanceToPoint(v2);
+
+        float t = distance1 / (distance1 - distance2);
+        Debug.Log(Vector3.Lerp(v1, v2, t));
+        return Vector3.Lerp(v1, v2, t);  // Interpolating to find the intersection point
+    }
+
+    // Generate a 2D polygon from the intersection points
+    void Generate2DPolygonFromIntersections(){
+        if (intersectionPoints.Count < 3){
+            Debug.LogWarning("Not enough points to form a polygon");
+            Debug.Log(intersectionPoints.Count);
+            return;
+        }
+        
+        List<Vector3> polygon2D = new List<Vector3>(); // Change 2d or 3d vectors here
+
+        foreach (Vector3 intersectionPoint in intersectionPoints)
+            // Convert 3D points into 2D (by discarding Z or using another plane of your choice)
+            polygon2D.Add(intersectionPoint);
+        
+        // Now it is needed to connect these points in a 2D space to create the polygon, triangulate the polygon for rendering in Unity
+        TriangulateAndRender2DPolygon(polygon2D);
+    }
+
+    // A simple function to triangulate and render the 2D polygon
+    void TriangulateAndRender2DPolygon(List<Vector3> polygon2D){
+        // Create a new GameObject for the 2D mesh
+        GameObject polygonObject = new GameObject("Sliced2DPolygon", typeof(MeshFilter), typeof(MeshRenderer));
+        
+        // Placeholder material for the polygon (replace with your own material)
+        polygonObject.GetComponent<MeshRenderer>().material = new Material(Shader.Find("Sprites/Default"));
+
+        // Triangulation: This assumes the polygon is convex and ordered correctly (or you could use a library like LibTessDotNet)
+        List<int> triangles = new List<int>();
+        for (int i = 1; i < polygon2D.Count - 1; i++){
+            triangles.Add(0);
+            triangles.Add(i);
+            triangles.Add(i + 1);
+        }
+
+        // Convert the 2D points back to 3D for rendering (setting Z = 0)
+        Vector3[] vertices3D = new Vector3[polygon2D.Count];
+        for (int i = 0; i < polygon2D.Count; i++)
+            vertices3D[i] = new Vector3(polygon2D[i].x, polygon2D[i].y, polygon2D[i].z);
+
+        // Create the 2D mesh
+        Mesh polygonMesh = new Mesh();
+        polygonMesh.vertices = vertices3D;
+        polygonMesh.triangles = triangles.ToArray();
+        polygonMesh.RecalculateNormals();
+        polygonMesh.RecalculateBounds();
+
+        // Assign the mesh to the MeshFilter
+        polygonObject.GetComponent<MeshFilter>().mesh = polygonMesh;
+    }
+}

--- a/Assets/Scripts/General/DimensionSwitcher.cs
+++ b/Assets/Scripts/General/DimensionSwitcher.cs
@@ -6,6 +6,8 @@ public class DimensionSwitcher : MonoBehaviour
     public Transform player;
     private Plane slicingPlane;
     public GameObject obj1;
+    public GameObject obj2;
+    public GameObject obj3;
 
     // Store the intersection points
     private List<Vector3> intersectionPoints = new List<Vector3>();
@@ -20,6 +22,10 @@ public class DimensionSwitcher : MonoBehaviour
             DrawSlicingPlane(slicingPlane, player.position);
             // Slice the object and generate 2D geometry
             SliceObject(obj1);
+            Generate2DPolygonFromIntersections();
+            SliceObject(obj2);
+            Generate2DPolygonFromIntersections();
+            SliceObject(obj3);
             Generate2DPolygonFromIntersections();
         }
     }
@@ -110,7 +116,7 @@ public class DimensionSwitcher : MonoBehaviour
         float distance2 = slicingPlane.GetDistanceToPoint(v2);
 
         float t = distance1 / (distance1 - distance2);
-        Debug.Log(Vector3.Lerp(v1, v2, t));
+        // Debug.Log(Vector3.Lerp(v1, v2, t));
         return Vector3.Lerp(v1, v2, t);  // Interpolating to find the intersection point
     }
 
@@ -118,7 +124,7 @@ public class DimensionSwitcher : MonoBehaviour
     void Generate2DPolygonFromIntersections(){
         if (intersectionPoints.Count < 3){
             Debug.LogWarning("Not enough points to form a polygon");
-            Debug.Log(intersectionPoints.Count);
+            // Debug.Log(intersectionPoints.Count);
             return;
         }
         
@@ -142,16 +148,37 @@ public class DimensionSwitcher : MonoBehaviour
 
         // Triangulation: This assumes the polygon is convex and ordered correctly (or you could use a library like LibTessDotNet)
         List<int> triangles = new List<int>();
+        for (int i = 0; i < polygon2D.Count; i++)
+        {
+            if (i != 0 && polygon2D[i] == polygon2D[i - 1])
+            {
+                // Shift elements one position back starting from the current position
+                for (int j = i; j < polygon2D.Count - 1; j++)
+                {
+                    polygon2D[j] = polygon2D[j + 1];
+                }
+
+                // Remove the last element since it's now a duplicate after shifting
+                polygon2D.RemoveAt(polygon2D.Count - 1);
+
+                // Decrement 'i' to recheck the current position (since it now contains the next element)
+                i--;
+            }
+        }
         for (int i = 1; i < polygon2D.Count - 1; i++){
             triangles.Add(0);
             triangles.Add(i);
             triangles.Add(i + 1);
         }
 
-        // Convert the 2D points back to 3D for rendering (setting Z = 0)
+        // Convert the 2D points back to 3D for rendering (setting Z = 0))
         Vector3[] vertices3D = new Vector3[polygon2D.Count];
-        for (int i = 0; i < polygon2D.Count; i++)
+        for (int i = 0; i < polygon2D.Count; i++){
             vertices3D[i] = new Vector3(polygon2D[i].x, polygon2D[i].y, polygon2D[i].z);
+            GameObject point = new GameObject("point " + i.ToString());
+            point.transform.position = vertices3D[i];
+        }
+            
 
         // Create the 2D mesh
         Mesh polygonMesh = new Mesh();

--- a/Assets/Scripts/General/DimensionSwitcher.cs.meta
+++ b/Assets/Scripts/General/DimensionSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a5b528f2ef90b44db15b30d23245d55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/General/LevelManager.cs
+++ b/Assets/Scripts/General/LevelManager.cs
@@ -23,7 +23,7 @@ public class LevelManager : MonoBehaviour
         Invoke("SwitchTo3D", 5f);
         ide2D.SetActive(true);
         foreach (var pair in transitionablePairs3D) {
-            pair.StartTransition();
+            pair.BeginTransition();
         }
         ide3D.SetActive(false);
     }
@@ -32,7 +32,7 @@ public class LevelManager : MonoBehaviour
         Invoke("SwitchTo2D", 5f);
         ide3D.SetActive(true);
         foreach (var pair in transitionablePairs2D) {
-            pair.StartTransition();
+            pair.BeginTransition();
         }
 
         ide2D.SetActive(false);

--- a/Assets/Scripts/General/TransitionablePair.cs
+++ b/Assets/Scripts/General/TransitionablePair.cs
@@ -9,13 +9,13 @@ public class TransitionablePair : MonoBehaviour
     private void Start(){
         posBeforeTransition = transform.position;
     }
-    
-    public void StartTransition(){ // Getting position of the first clone in the dimension player is switching OUT of
+    public void BeginTransition(){ // Getting position of the first clone in the dimension player is switching OUT of
         Vector3 changeInPosition = transform.position - posBeforeTransition;
-        changeInPosition.z = 0; // Does not matter a lot, but if moved too far away a 2D object can be out of range for cameras
-        target.ReceiveTransition(changeInPosition);       
+        // changeInPosition.z = 0; // Does not matter a lot, but if moved too far away a 2D object can be out of range for cameras
+        target.FinishTransition(changeInPosition);       
         posBeforeTransition = transform.position; // Next transition the current position will be used as the first point
-    } private void ReceiveTransition(Vector3 changeInPosition){ // Moving the clone in the dimension player is switching IN to
+    } 
+    private void FinishTransition(Vector3 changeInPosition){ // Moving the clone in the dimension player is switching IN to
         transform.position = transform.position + changeInPosition;
         posBeforeTransition = transform.position; // Next transition the current position will be used as the first point
     }

--- a/Assets/Scripts/General/TransitionablePair.cs
+++ b/Assets/Scripts/General/TransitionablePair.cs
@@ -2,8 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class TransitionablePair : MonoBehaviour
-{
+public class TransitionablePair : MonoBehaviour {
+    // This code currently is only used for the player objects, since they cannot be created from one object both in 2D and 3D
+    // The 3D and 2D models have to be teleported to new locations after transitioning
     public TransitionablePair target; // A clone of this object in the other dimension
     private Vector3 posBeforeTransition;
     private void Start(){


### PR DESCRIPTION
Inside the Dimension Switcher new logic has been implemented, allowing the player to slice all 3d objects into 2d slices or "shadows" using the current plane they are facing (their rotation is used to determine the plane's normal). It does not include colliders, textures or materials, the script only creates a new game object with a new mesh (a white 2d figure). 